### PR TITLE
Update detector ID structure

### DIFF
--- a/include/Ecal/EcalClusterProducer.h
+++ b/include/Ecal/EcalClusterProducer.h
@@ -23,7 +23,7 @@
 #include "Event/EcalCluster.h"
 #include "Event/ClusterAlgoResult.h"
 #include "DetDescr/DetectorID.h"
-#include "DetDescr/EcalDetectorID.h"
+#include "DetDescr/EcalID.h"
 #include "DetDescr/EcalHexReadout.h"
 #include "Framework/EventProcessor.h"
 #include "Framework/Parameters.h" 

--- a/include/Ecal/EcalDigiProducer.h
+++ b/include/Ecal/EcalDigiProducer.h
@@ -29,7 +29,7 @@
 #include "Event/EcalDigiCollection.h"
 #include "Event/EventConstants.h"
 #include "Event/SimCalorimeterHit.h"
-#include "DetDescr/EcalDetectorID.h"
+#include "DetDescr/EcalID.h"
 #include "DetDescr/EcalHexReadout.h"
 #include "Framework/EventProcessor.h"
 #include "Tools/NoiseGenerator.h"

--- a/include/Ecal/EcalRecProducer.h
+++ b/include/Ecal/EcalRecProducer.h
@@ -25,7 +25,7 @@
 //----------//
 #include "Event/EventDef.h"
 #include "DetDescr/DetectorID.h"
-#include "DetDescr/EcalDetectorID.h"
+#include "DetDescr/EcalID.h"
 #include "DetDescr/EcalHexReadout.h"
 #include "Framework/EventProcessor.h"
 #include "Tools/NoiseGenerator.h"
@@ -111,12 +111,6 @@ namespace ldmx {
              * of a calibration number.
              */
             double secondOrderEnergyCorrection_;
-
-            /** 
-             * Helper Instance of EcalDetectorID:
-             * used to translate the raw ID to layer, module, cell IDs
-             */
-            EcalDetectorID detID_;
 
             /**
              * Helper Instance of EcalHexReadout:

--- a/include/Ecal/EcalSim2Rec.h
+++ b/include/Ecal/EcalSim2Rec.h
@@ -24,7 +24,7 @@
 //----------//
 #include "Event/EventDef.h"
 #include "DetDescr/DetectorID.h"
-#include "DetDescr/EcalDetectorID.h"
+#include "DetDescr/EcalID.h"
 #include "DetDescr/EcalHexReadout.h"
 #include "Framework/EventProcessor.h"
 #include "Tools/NoiseGenerator.h"
@@ -72,11 +72,9 @@ namespace ldmx {
             } 
             
             inline layer_cell_pair hitToPair(const SimCalorimeterHit &hit) {
-                int detIDraw = hit.getID();
-                detID_.setRawValue(detIDraw);
-                detID_.unpack();
-                int layer = detID_.getFieldValue("layer");
-                int cellid = detID_.getFieldValue("cell");
+		EcalID id(hit.getID());
+                int layer = id.layer();
+                int cellid = id.cell();
                 return (std::make_pair(layer, cellid));
             }
 
@@ -101,7 +99,6 @@ namespace ldmx {
             static const int TOTAL_CELLS{NUM_ECAL_LAYERS*HEX_MODULES_PER_LAYER*CELLS_PER_HEX_MODULE};
 
             std::unique_ptr<TRandom3> noiseInjector_;
-            EcalDetectorID detID_;
             std::unique_ptr<EcalHexReadout> hexReadout_;
             /** Generator of noise hits. */ 
             std::unique_ptr<NoiseGenerator> noiseGenerator_; 

--- a/include/Ecal/EcalVetoProcessor.h
+++ b/include/Ecal/EcalVetoProcessor.h
@@ -66,11 +66,11 @@ namespace ldmx {
             XYCoords getCellCentroidXYPair(EcalID centroidID){
                 return hexReadout_->getCellCenterAbsolute(centroidID);
             }
-            std::vector<EcalID> getInnerRingCellIds(EcalID cellModuleID){
-                return hexReadout_->getNN(cellModuleID);
+            std::vector<EcalID> getInnerRingCellIds(EcalID id){
+                return hexReadout_->getNN(id);
             }
-            std::vector<EcalID> getOuterRingCellIds(EcalID cellModuleID){
-                return hexReadout_->getNNN(cellModuleID);
+            std::vector<EcalID> getOuterRingCellIds(EcalID id){
+                return hexReadout_->getNNN(id);
             }
 
             void clearProcessor();
@@ -82,13 +82,13 @@ namespace ldmx {
 
             /* Function to load up empty vector of hit maps */
             void fillHitMap(const std::vector< EcalHit > &ecalRecHits,
-                    std::vector<std::map<EcalID, float>>& cellMap_);
+                    std::map<EcalID, float>& cellMap_);
 
             /* Function to take loaded hit maps and find isolated hits in them */
             void fillIsolatedHitMap(const std::vector< EcalHit > &ecalRecHits,
                     EcalID globalCentroid,
-                    std::vector<std::map<EcalID, float>>& cellMap_,
-                    std::vector<std::map<EcalID, float>>& cellMapIso_,
+                    std::map<EcalID, float>& cellMap_,
+                    std::map<EcalID, float>& cellMapIso_,
                     bool doTight = false);
 
             std::vector<XYCoords> getTrajectory(std::vector<double> momentum, std::vector<float> position);
@@ -96,8 +96,8 @@ namespace ldmx {
             void buildBDTFeatureVector(const ldmx::EcalVetoResult& result);
 
         private:
-            std::vector<std::map<EcalID, float>> cellMap_;
-            std::vector<std::map<EcalID, float>> cellMapTightIso_;
+            std::map<EcalID, float> cellMap_;
+            std::map<EcalID, float> cellMapTightIso_;
 
             std::vector<float> ecalLayerEdepRaw_;
             std::vector<float> ecalLayerEdepReadout_;

--- a/include/Ecal/EcalVetoProcessor.h
+++ b/include/Ecal/EcalVetoProcessor.h
@@ -9,7 +9,7 @@
 
 // LDMX
 #include "DetDescr/EcalHexReadout.h"
-#include "DetDescr/EcalDetectorID.h"
+#include "DetDescr/EcalID.h"
 #include "Event/EventDef.h"
 #include "Framework/EventProcessor.h"
 #include "Framework/Parameters.h"
@@ -32,9 +32,7 @@ namespace ldmx {
 
         public:
 
-            typedef std::pair<int, int> LayerCellPair;
-
-            typedef std::pair<int, float> CellEnergyPair;
+      typedef std::pair<EcalID, float> CellEnergyPair;
 
             typedef std::pair<float, float> XYCoords;
 
@@ -59,38 +57,38 @@ namespace ldmx {
              *  Necessary to easily combine cellID with moduleID to get unique ID of
              *  hit in layer. In future: combine celID+moduleID+layerID.
              */
-            bool isInShowerInnerRing(int centroidID, int probeID){
+            bool isInShowerInnerRing(EcalID centroidID, EcalID probeID){
                 return hexReadout_->isNN(centroidID, probeID);
             }
-            bool isInShowerOuterRing(int centroidID, int probeID){
+            bool isInShowerOuterRing(EcalID centroidID, EcalID probeID){
                 return hexReadout_->isNNN(centroidID, probeID);
             }
-            XYCoords getCellCentroidXYPair(int centroidID){
+            XYCoords getCellCentroidXYPair(EcalID centroidID){
                 return hexReadout_->getCellCenterAbsolute(centroidID);
             }
-            std::vector<int> getInnerRingCellIds(int cellModuleID){
+            std::vector<EcalID> getInnerRingCellIds(EcalID cellModuleID){
                 return hexReadout_->getNN(cellModuleID);
             }
-            std::vector<int> getOuterRingCellIds(int cellModuleID){
+            std::vector<EcalID> getOuterRingCellIds(EcalID cellModuleID){
                 return hexReadout_->getNNN(cellModuleID);
             }
 
             void clearProcessor();
 
-            LayerCellPair hitToPair(const EcalHit &hit);
+            EcalID hitID(const EcalHit &hit) const { return EcalID(hit.getID()); }
 
             /* Function to calculate the energy weighted shower centroid */
-            int GetShowerCentroidIDAndRMS(const std::vector< EcalHit > &ecalRecHits, double & showerRMS);
+            EcalID GetShowerCentroidIDAndRMS(const std::vector< EcalHit > &ecalRecHits, double & showerRMS);
 
             /* Function to load up empty vector of hit maps */
             void fillHitMap(const std::vector< EcalHit > &ecalRecHits,
-                    std::vector<std::map<int, float>>& cellMap_);
+                    std::vector<std::map<EcalID, float>>& cellMap_);
 
             /* Function to take loaded hit maps and find isolated hits in them */
             void fillIsolatedHitMap(const std::vector< EcalHit > &ecalRecHits,
-                    float globalCentroid,
-                    std::vector<std::map<int, float>>& cellMap_,
-                    std::vector<std::map<int, float>>& cellMapIso_,
+                    EcalID globalCentroid,
+                    std::vector<std::map<EcalID, float>>& cellMap_,
+                    std::vector<std::map<EcalID, float>>& cellMapIso_,
                     bool doTight = false);
 
             std::vector<XYCoords> getTrajectory(std::vector<double> momentum, std::vector<float> position);
@@ -98,8 +96,8 @@ namespace ldmx {
             void buildBDTFeatureVector(const ldmx::EcalVetoResult& result);
 
         private:
-            std::vector<std::map<int, float>> cellMap_;
-            std::vector<std::map<int, float>> cellMapTightIso_;
+            std::vector<std::map<EcalID, float>> cellMap_;
+            std::vector<std::map<EcalID, float>> cellMapTightIso_;
 
             std::vector<float> ecalLayerEdepRaw_;
             std::vector<float> ecalLayerEdepReadout_;
@@ -127,7 +125,6 @@ namespace ldmx {
 
             double bdtCutVal_{0};
 
-            EcalDetectorID detID_;
             bool verbose_{false};
             bool doesPassVeto_{false};
 

--- a/python/digi.py
+++ b/python/digi.py
@@ -31,6 +31,9 @@ class EcalDigiProducer(Producer) :
         self.nADCs = 10
         self.iSOI  = 0
 
+        import time
+        self.randomSeed = int(time.time())
+
 class EcalRecProducer(Producer) :
     """Configuration for the EcalRecProducer
 

--- a/src/DNNEcalVetoProcessor.cxx
+++ b/src/DNNEcalVetoProcessor.cxx
@@ -148,10 +148,11 @@ namespace ldmx {
       data_[0].at(coordinate_y_offset_ + idx) = y;
       data_[0].at(coordinate_z_offset_ + idx) = z;
 
+      EcalID id(hit.getID());
       data_[1].at(feature_x_offset_ + idx) = x;
       data_[1].at(feature_y_offset_ + idx) = y;
       data_[1].at(feature_z_offset_ + idx) = z;
-      data_[1].at(feature_layerid_offset_ + idx) = hit.getLayer();
+      data_[1].at(feature_layerid_offset_ + idx) = id.layer();
       data_[1].at(feature_energy_offset_ + idx) = std::log(hit.getEnergy());
 
       ++idx;

--- a/src/EcalClusterProducer.cxx
+++ b/src/EcalClusterProducer.cxx
@@ -92,7 +92,8 @@ namespace ldmx {
             //Skip zero energy digis.
             if (hit.getEnergy() == 0) { continue; }
 
-            cf.add( &hit , hexReadout_, layerZPos[hit.getLayer()]);
+            EcalID id(hit.getID());
+            cf.add( &hit , hexReadout_, layerZPos[id.layer()]);
         }
 
         cf.cluster(seedThreshold_, cutoff_);

--- a/src/EcalDigiProducer.cxx
+++ b/src/EcalDigiProducer.cxx
@@ -126,7 +126,7 @@ namespace ldmx {
 
         //put noise into some empty channels
         int numEmptyChannels = TOTAL_NUM_CHANNELS - ecalDigis.getNumDigis();
-        EcalDetectorID detID;
+        EcalID detID;
         auto noiseHitAmplitudes{noiseGenerator_->generateNoiseHits(numEmptyChannels)};
         for ( double noiseHit : noiseHitAmplitudes ) {
 
@@ -137,10 +137,8 @@ namespace ldmx {
                 int layerID = noiseInjector_->Integer(NUM_ECAL_LAYERS);
                 int moduleID= noiseInjector_->Integer(NUM_HEX_MODULES_PER_LAYER);
                 int cellID  = noiseInjector_->Integer(CELLS_PER_HEX_MODULE);
-                detID.setFieldValue( 1 , layerID );
-                detID.setFieldValue( 2 , moduleID );
-                detID.setFieldValue( 3 , cellID );
-                noiseID = detID.pack();
+		detID=EcalID(layerID, moduleID, cellID);
+                noiseID = detID.raw();
             } while ( simHitIDs.find( noiseID ) != simHitIDs.end() );
 
             //get a time for this noise hit

--- a/src/EcalDigiProducer.cxx
+++ b/src/EcalDigiProducer.cxx
@@ -25,11 +25,6 @@ namespace ldmx {
         //  how many hits should be generated for a given number of empty
         //  channels and a minimum readout value (setNoiseThreshold)
         noiseGenerator_ = std::make_unique<NoiseGenerator>();
-
-        //The noise injector is used to place smearing on top
-        //of energy depositions and hit times before doing
-        //the digitization procedure.
-        noiseInjector_ = std::make_unique<TRandom3>(time(nullptr));
     }
 
     EcalDigiProducer::~EcalDigiProducer() { }
@@ -58,7 +53,10 @@ namespace ldmx {
         noiseGenerator_->setPedestal(0); //mean noise amplitude (if using Gaussian Model for the noise) in MeV
         noiseGenerator_->setNoiseThreshold(readoutThreshold_); //threshold for readout in MeV
 
-        noiseInjector_->SetSeed(0);
+        //The noise injector is used to place smearing on top
+        //of energy depositions and hit times before doing
+        //the digitization procedure.
+        noiseInjector_ = std::make_unique<TRandom3>(ps.getParameter<int>("randomSeed"));
 
         pulseFunc_ = TF1(
                 "pulseFunc",

--- a/src/EcalRecProducer.cxx
+++ b/src/EcalRecProducer.cxx
@@ -94,11 +94,11 @@ namespace ldmx {
             //Right now, hard-coded to only use one sample in EcalDigiProducer
             //TODO: expand to multiple samples per digi
             EcalDigiSample sample = (ecalDigis.getDigi( iDigi )).at(0);
-            int rawID = sample.rawID_;
+            EcalID id(sample.rawID_);
             
             //ID to real space position
             double x,y,z;
-            ecalHexReadout_->getCellAbsolutePosition( rawID , x , y , z );
+            ecalHexReadout_->getCellAbsolutePosition( id , x , y , z );
             
             //get energy and time estimate from digi information
             double siEnergy, hitTime;
@@ -128,15 +128,13 @@ namespace ldmx {
             //printf( "%6d Clocks and %6d tot --> %6.2f MeV\n" , sample.adc_t_ , sample.tot_ , siEnergy );
             
             //incorporate layer weights
-            detID_.setRawValue( rawID );
-            detID_.unpack();
-            int layer = detID_.getLayerID();
+            int layer = id.layer();
             double recHitEnergy = 
                 ( (siEnergy / MIP_SI_RESPONSE)*layerWeights_.at(layer)+siEnergy )*secondOrderEnergyCorrection_;
 
             //copy over information to rec hit structure in new collection
             EcalHit recHit;
-            recHit.setID( rawID );
+            recHit.setID( id.raw() );
             recHit.setXPos( x );
             recHit.setYPos( y );
             recHit.setZPos( z );

--- a/src/EcalSim2Rec.cxx
+++ b/src/EcalSim2Rec.cxx
@@ -153,10 +153,8 @@ namespace ldmx {
             //std::cout << "[ EcalSim2Rec ]: Random module ID: " << moduleID << std::endl;
             int cellID = noiseInjector_->Integer(CELLS_PER_HEX_MODULE); 
             //std::cout << "[ EcalSim2Rec ]: Random cell ID: " << cellID << std::endl;
-            detID_.setFieldValue(1, layerID); 
-            detID_.setFieldValue(2, moduleID); 
-            detID_.setFieldValue(3, cellID); 
-            recHit.setID(detID_.pack()); 
+	    EcalID id(layerID,moduleID,cellID);
+            recHit.setID(id.raw()); 
 
             // Set the calibrated energy of the hit
             recHit.setEnergy(((noiseHit/MIP_SI_RESPONSE)*layerWeights_.at(layerID)+noiseHit)*secondOrderEnergyCorrection_);

--- a/src/EcalVetoProcessor.cxx
+++ b/src/EcalVetoProcessor.cxx
@@ -283,7 +283,7 @@ namespace ldmx {
             //Layer-wise quantities
 	    EcalID id=hitID(hit);
             ecalLayerEdepRaw_[id.layer()] = ecalLayerEdepRaw_[id.layer()] + hit.getEnergy();
-            if(hit.getLayer() >= 20)
+            if(id.layer() >= 20)
                 ecalBackEnergy_ += hit.getEnergy();
             if (maxCellDep_ < hit.getEnergy())
                 maxCellDep_ = hit.getEnergy();
@@ -293,21 +293,21 @@ namespace ldmx {
                 ecalLayerTime_[id.layer()] += (hit.getEnergy()) * hit.getTime();
                 xMean += getCellCentroidXYPair(id).first * hit.getEnergy();
                 yMean += getCellCentroidXYPair(id).second * hit.getEnergy();
-                avgLayerHit_ += hit.getLayer();
-                wavgLayerHit += hit.getLayer() * hit.getEnergy();
-                if (deepestLayerHit_ < hit.getLayer()) {
-                    deepestLayerHit_ = hit.getLayer();
+                avgLayerHit_ += id.layer();
+                wavgLayerHit += id.layer() * hit.getEnergy();
+                if (deepestLayerHit_ < id.layer()) {
+                    deepestLayerHit_ = id.layer();
                 }
                 XYCoords xy_pair = getCellCentroidXYPair(id);
-                float distance_ele_trajectory = ele_trajectory.size() ? sqrt( pow((xy_pair.first - ele_trajectory[hit.getLayer()].first),2) + pow((xy_pair.second - ele_trajectory[hit.getLayer()].second),2) ) : -1.0;
-                float distance_photon_trajectory = photon_trajectory.size() ? sqrt( pow((xy_pair.first - photon_trajectory[hit.getLayer()].first),2) + pow((xy_pair.second - photon_trajectory[hit.getLayer()].second),2) ) : -1.0;
+                float distance_ele_trajectory = ele_trajectory.size() ? sqrt( pow((xy_pair.first - ele_trajectory[id.layer()].first),2) + pow((xy_pair.second - ele_trajectory[id.layer()].second),2) ) : -1.0;
+                float distance_photon_trajectory = photon_trajectory.size() ? sqrt( pow((xy_pair.first - photon_trajectory[id.layer()].first),2) + pow((xy_pair.second - photon_trajectory[id.layer()].second),2) ) : -1.0;
                 // Decide which region a hit goes into and add to sums
                 for(unsigned int ireg = 0; ireg < nregions; ireg++) {
-                    if(distance_ele_trajectory >= ireg*ele_radii[hit.getLayer()] && distance_ele_trajectory < (ireg+1)*ele_radii[hit.getLayer()])
+                    if(distance_ele_trajectory >= ireg*ele_radii[id.layer()] && distance_ele_trajectory < (ireg+1)*ele_radii[id.layer()])
                         electronContainmentEnergy[ireg] += hit.getEnergy();
-                    if(distance_photon_trajectory >= ireg*photon_radii[hit.getLayer()] && distance_photon_trajectory < (ireg+1)*photon_radii[hit.getLayer()])
+                    if(distance_photon_trajectory >= ireg*photon_radii[id.layer()] && distance_photon_trajectory < (ireg+1)*photon_radii[id.layer()])
                         photonContainmentEnergy[ireg] += hit.getEnergy();
-                    if(distance_ele_trajectory > (ireg+1)*ele_radii[hit.getLayer()] && distance_photon_trajectory > (ireg+1)*photon_radii[hit.getLayer()]) {
+                    if(distance_ele_trajectory > (ireg+1)*ele_radii[id.layer()] && distance_photon_trajectory > (ireg+1)*photon_radii[id.layer()]) {
                         outsideContainmentEnergy[ireg] += hit.getEnergy();
                         outsideContainmentNHits[ireg] += 1;
                         outsideContainmentXmean[ireg] += xy_pair.first*hit.getEnergy();
@@ -351,13 +351,13 @@ namespace ldmx {
             if (hit.getEnergy() > 0) {
                 xStd_ += pow((getCellCentroidXYPair(id).first - xMean), 2) * hit.getEnergy();
                 yStd_ += pow((getCellCentroidXYPair(id).second - yMean), 2) * hit.getEnergy();
-                stdLayerHit_ += pow((hit.getLayer() - wavgLayerHit), 2) * hit.getEnergy();
+                stdLayerHit_ += pow((id.layer() - wavgLayerHit), 2) * hit.getEnergy();
             }
             XYCoords xy_pair = getCellCentroidXYPair(id);
-            float distance_ele_trajectory = ele_trajectory.size() ? sqrt( pow((xy_pair.first - ele_trajectory[hit.getLayer()].first),2) + pow((xy_pair.second - ele_trajectory[hit.getLayer()].second),2) ) : -1.0;
-            float distance_photon_trajectory = photon_trajectory.size() ? sqrt( pow((xy_pair.first - photon_trajectory[hit.getLayer()].first),2) + pow((xy_pair.second - photon_trajectory[hit.getLayer()].second),2) ) : -1.0;
+            float distance_ele_trajectory = ele_trajectory.size() ? sqrt( pow((xy_pair.first - ele_trajectory[id.layer()].first),2) + pow((xy_pair.second - ele_trajectory[id.layer()].second),2) ) : -1.0;
+            float distance_photon_trajectory = photon_trajectory.size() ? sqrt( pow((xy_pair.first - photon_trajectory[id.layer()].first),2) + pow((xy_pair.second - photon_trajectory[id.layer()].second),2) ) : -1.0;
             for(unsigned int ireg = 0; ireg < nregions; ireg++) {
-                if(distance_ele_trajectory > (ireg+1)*ele_radii[hit.getLayer()] && distance_photon_trajectory > (ireg+1)*photon_radii[hit.getLayer()]) {
+                if(distance_ele_trajectory > (ireg+1)*ele_radii[id.layer()] && distance_photon_trajectory > (ireg+1)*photon_radii[id.layer()]) {
                     outsideContainmentXstd[ireg] += pow((xy_pair.first - outsideContainmentXmean[ireg]),2) * hit.getEnergy();
                     outsideContainmentYstd[ireg] += pow((xy_pair.second - outsideContainmentYmean[ireg]),2) * hit.getEnergy();
                 }

--- a/test/EcalDigiPipelineTest.cxx
+++ b/test/EcalDigiPipelineTest.cxx
@@ -75,7 +75,8 @@ TEST_CASE( "Ecal Digi Pipeline test" , "[Ecal][functionality]" ) {
         //TODO test several contribs
         //  right now, not a big deal because we just do an energy weight average anyways
         SimCalorimeterHit currHit;
-        currHit.setID( index++ );
+	EcalID id(0,1,index++);
+        currHit.setID( id.raw() );
         currHit.addContrib(
                 -1 //incidentID
                 , -1 // trackID


### PR DESCRIPTION
@jmmans Put this together to make the detector ID (1) more realistic and (2) more robust. I am making this PR to store the list of checks we want to do in the Ecal chain.

## Checks
- [x] Compile and run entire ecal digi pipeline
- [x] Ecal veto compiles and runs
- [x] Ecal veto's values don't change comparing to master when run with the same seeds (start at sim stage)

The detector ID changes span several submodules, so the checks need to be done where all the submodules (except MagFieldMap and Framework) are on the iss876 branch.