### PR TITLE
Make collection names settable parameters for digi and reco 

### DIFF
--- a/include/Ecal/EcalDigiProducer.h
+++ b/include/Ecal/EcalDigiProducer.h
@@ -67,6 +67,15 @@ class EcalDigiProducer : public Producer {
             ///////////////////////////////////////////////////////////////////////////////////////
             //Python Configuration Parameters
 
+	        /// input hit collection name
+            std::string inputCollName_;
+
+	        /// input pass name
+            std::string inputPassName_;
+
+	        /// output hit collection name
+            std::string outputCollName_;
+	  
             /// Time interval for chip clock in ns
             double clockCycle_;
 

--- a/include/Ecal/EcalDigiProducer.h
+++ b/include/Ecal/EcalDigiProducer.h
@@ -67,13 +67,13 @@ class EcalDigiProducer : public Producer {
             ///////////////////////////////////////////////////////////////////////////////////////
             //Python Configuration Parameters
 
-	        /// input hit collection name
+            /// input hit collection name
             std::string inputCollName_;
 
-	        /// input pass name
+            /// input pass name
             std::string inputPassName_;
 
-	        /// output hit collection name
+            /// output hit collection name
             std::string outputCollName_;
 	  
             /// Time interval for chip clock in ns

--- a/include/Ecal/EcalRecProducer.h
+++ b/include/Ecal/EcalRecProducer.h
@@ -71,7 +71,7 @@ namespace ldmx {
             std::string simHitCollName_;
 
             /// simhit pass name
-	        std::string simHitPassName_;
+            std::string simHitPassName_;
 
             /// output hit collection name
             std::string recHitCollName_;

--- a/include/Ecal/EcalRecProducer.h
+++ b/include/Ecal/EcalRecProducer.h
@@ -67,6 +67,15 @@ namespace ldmx {
             /** Digi Pass Name to use as input */
             std::string digiPassName_;
 
+            /// simhit collection name                                                                                                     
+            std::string simHitCollName_;
+
+            /// simhit pass name
+	        std::string simHitPassName_;
+
+            /// output hit collection name
+            std::string recHitCollName_;
+	  
             /// Energy [MeV] deposited by a MIP in Si 0.5mm thick
             double mipSiEnergy_;
 

--- a/python/digi.py
+++ b/python/digi.py
@@ -69,6 +69,11 @@ class EcalDigiProducer(Producer) :
         #   this leads to ~ 470 mV/MeV or ~6.8 MeV maximum hit (if 320 fC is max ADC range)
         self.MeV = (1./mipSiEnergy)*self.hgcroc.calculateVoltage( nElectronsPerMIP )
 
+        # input and output collection name parameters
+        self.inputCollName = 'EcalSimHits'
+        self.inputPassName = ''
+        self.digiCollName = 'EcalDigis'
+
 
 class EcalRecProducer(Producer) :
     """Configuration for the EcalRecProducer
@@ -109,7 +114,10 @@ class EcalRecProducer(Producer) :
 
         self.digiCollName = 'EcalDigis'
         self.digiPassName = ''
-
+        self.simHitCollName = 'EcalSimHits'
+        self.simHitPassName = ''
+        self.recHitCollName = 'EcalRecHits'
+        
         # geometry dependent settings
         # use helper functions to set these
         self.secondOrderEnergyCorrection = 1.

--- a/src/EcalDigiProducer.cxx
+++ b/src/EcalDigiProducer.cxx
@@ -35,6 +35,11 @@ namespace ldmx {
         nADCs_            = hgcrocParams.getParameter<int>("nADCs");
         iSOI_             = hgcrocParams.getParameter<int>("iSOI");
 
+		//collection names
+		input_collection_  = ps.getParameter<std::string>("inputCollName");
+		input_pass_name_  = ps.getParameter<std::string>("inputPassName");
+		output_collection_ = ps.getParameter<std::string>("digiCollName");
+
         // physical constants
         //  used to calculate unit conversions
         MeV_ = ps.getParameter<double>("MeV");
@@ -82,7 +87,7 @@ namespace ldmx {
         //  the class EcalHitIO in the SimApplication module handles the translation from G4CalorimeterHits to SimCalorimeterHits
         //  this class ensures that only one SimCalorimeterHit is generated per cell, but
         //  multiple "contributions" are still handled within SimCalorimeterHit 
-        auto ecalSimHits{event.getCollection<SimCalorimeterHit>(EventConstants::ECAL_SIM_HITS)};
+		auto ecalSimHits{event.getCollection<SimCalorimeterHit>(input_collection_, input_pass_name_)};
 
         /* debug printout
         std::cout << "Energy to Voltage Conversion: " << MeV_ << " mV/MeV" << std::endl;
@@ -159,7 +164,7 @@ namespace ldmx {
             } //loop over noise amplitudes
         } //if we should do the noise
 
-        event.add("EcalDigis", ecalDigis );
+        event.add(output_collection_, ecalDigis );
 
         return;
     } //produce

--- a/src/EcalDigiProducer.cxx
+++ b/src/EcalDigiProducer.cxx
@@ -35,10 +35,10 @@ namespace ldmx {
         nADCs_            = hgcrocParams.getParameter<int>("nADCs");
         iSOI_             = hgcrocParams.getParameter<int>("iSOI");
 
-		//collection names
-		input_collection_  = ps.getParameter<std::string>("inputCollName");
-		input_pass_name_  = ps.getParameter<std::string>("inputPassName");
-		output_collection_ = ps.getParameter<std::string>("digiCollName");
+        //collection names
+        inputCollName_  = ps.getParameter<std::string>("inputCollName");
+        inputPassName_  = ps.getParameter<std::string>("inputPassName");
+        digiCollName_   = ps.getParameter<std::string>("digiCollName");
 
         // physical constants
         //  used to calculate unit conversions
@@ -87,7 +87,7 @@ namespace ldmx {
         //  the class EcalHitIO in the SimApplication module handles the translation from G4CalorimeterHits to SimCalorimeterHits
         //  this class ensures that only one SimCalorimeterHit is generated per cell, but
         //  multiple "contributions" are still handled within SimCalorimeterHit 
-		auto ecalSimHits{event.getCollection<SimCalorimeterHit>(input_collection_, input_pass_name_)};
+		auto ecalSimHits{event.getCollection<SimCalorimeterHit>(inputCollName_, inputPassName_)};
 
         /* debug printout
         std::cout << "Energy to Voltage Conversion: " << MeV_ << " mV/MeV" << std::endl;
@@ -164,7 +164,7 @@ namespace ldmx {
             } //loop over noise amplitudes
         } //if we should do the noise
 
-        event.add(output_collection_, ecalDigis );
+        event.add( digiCollName_, ecalDigis );
 
         return;
     } //produce

--- a/src/EcalRecProducer.cxx
+++ b/src/EcalRecProducer.cxx
@@ -17,7 +17,7 @@ namespace ldmx {
 
     void EcalRecProducer::configure(Parameters& ps) {
 
-		//collection names
+        //collection names
         digiCollName_ = ps.getParameter<std::string>( "digiCollName" );
         digiPassName_ = ps.getParameter<std::string>( "digiPassName" );
         simHitCollName_  = ps.getParameter<std::string>("simHitCollName");
@@ -43,7 +43,7 @@ namespace ldmx {
     void EcalRecProducer::produce(Event& event) {
         // Get the Ecal Geometry
         const EcalHexReadout& hexReadout = getCondition<EcalHexReadout>(EcalHexReadout::CONDITIONS_OBJECT_NAME);
-	
+
         std::vector<EcalHit> ecalRecHits;
         auto ecalDigis = event.getObject<HgcrocDigiCollection>( digiCollName_ , digiPassName_ );
         int numDigiHits = ecalDigis.getNumDigis();
@@ -156,7 +156,7 @@ namespace ldmx {
 
         if (event.exists( simHitCollName_, simHitPassName_ )) {
             //ecal sim hits exist ==> label which hits are real and which are pure noise
-		  auto ecalSimHits{event.getCollection<SimCalorimeterHit>( simHitCollName_, simHitPassName_ )};
+            auto ecalSimHits{event.getCollection<SimCalorimeterHit>( simHitCollName_, simHitPassName_ )};
             std::set<int> real_hits;
             for ( auto const& sim_hit : ecalSimHits ) real_hits.insert( sim_hit.getID() );
             for ( auto& hit : ecalRecHits ) hit.setNoise( real_hits.find(hit.getID()) == real_hits.end() );

--- a/src/EcalRecProducer.cxx
+++ b/src/EcalRecProducer.cxx
@@ -20,8 +20,8 @@ namespace ldmx {
 		//collection names
         digiCollName_ = ps.getParameter<std::string>( "digiCollName" );
         digiPassName_ = ps.getParameter<std::string>( "digiPassName" );
-		simHitCollName_  = ps.getParameter<std::string>("simHitCollName");
-		simHitPassName_  = ps.getParameter<std::string>("simHitPassName");
+        simHitCollName_  = ps.getParameter<std::string>("simHitCollName");
+        simHitPassName_  = ps.getParameter<std::string>("simHitPassName");
         recHitCollName_ = ps.getParameter<std::string>("recHitCollName");
 
         layerWeights_ = ps.getParameter<std::vector<double>>( "layerWeights" );


### PR DESCRIPTION
This enables running over overlay collections (also, nicely, to compare digi and reco of non-overlay to that of overlay in one go).