### PR TITLE
Update noise creation

### DIFF
--- a/include/Ecal/EcalDigiProducer.h
+++ b/include/Ecal/EcalDigiProducer.h
@@ -85,6 +85,23 @@ class EcalDigiProducer : public framework::Producer {
   /// Conversion from energy in MeV to voltage in mV
   double MeV_;
 
+  /**
+   * When emulating noise in empty channels, do we zero suppress?
+   *
+   * There are two ways to emulate the noise in the chip:
+   *  1) (with zero suppression) Use the NoiseGenerator to get a list of 
+   *     amplitudes (about 3-5 on avg) and put those noise hits which are
+   *     above the readout threshold in random empty channels.
+   *  2) (without zero suppresion) Go through all channels and put 
+   *     noise in each channel that doesn't have a real hit in it.
+   *     This will mean many channels with have a DIGI below readout
+   *     threshold.
+   */
+  bool zero_suppression_;
+
+  /// Store Average Noise RMS for no-zero-suppresion noise emulation mode
+  double avgNoiseRMS_;
+
   ///////////////////////////////////////////////////////////////////////////////////////
   // Other member variables
 

--- a/python/digi.py
+++ b/python/digi.py
@@ -89,7 +89,7 @@ class EcalDigiProducer(Producer) :
         self.avgPedestal = 50.*avgGain
 
         # Should we suppress noise "hits" below readout threshold?
-        self.zero_suppression = False
+        self.zero_suppression = True
 
         # input and output collection name parameters
         self.inputCollName = 'EcalSimHits'

--- a/python/digi.py
+++ b/python/digi.py
@@ -57,6 +57,12 @@ class EcalDigiProducer(Producer) :
         Configuration for the chip emulator
     MeV : float
         Conversion between energy [MeV] and voltage [mV]
+    avgReadoutThreshold : float
+        Average readout threshold for all channels [mV], for noise emulation
+    avgPedestal : float
+        Average pedestal for all channels [mV], for noise emulation
+    zero_suppresion : bool
+        Should we suppress pure noise "hits" below readout threshold?
     inputCollName : str
         Name of simulated ecal hits to digitize
     inputPassName : str
@@ -81,6 +87,9 @@ class EcalDigiProducer(Producer) :
         avgGain = 0.3125/20.
         self.avgReadoutThreshold = 53.*avgGain
         self.avgPedestal = 50.*avgGain
+
+        # Should we suppress noise "hits" below readout threshold?
+        self.zero_suppresion = False
 
         # input and output collection name parameters
         self.inputCollName = 'EcalSimHits'

--- a/python/digi.py
+++ b/python/digi.py
@@ -89,7 +89,7 @@ class EcalDigiProducer(Producer) :
         self.avgPedestal = 50.*avgGain
 
         # Should we suppress noise "hits" below readout threshold?
-        self.zero_suppresion = False
+        self.zero_suppression = False
 
         # input and output collection name parameters
         self.inputCollName = 'EcalSimHits'

--- a/src/Ecal/EcalDigiProducer.cxx
+++ b/src/Ecal/EcalDigiProducer.cxx
@@ -201,9 +201,11 @@ void EcalDigiProducer::produce(framework::Event& event) {
       }  // loop over noise amplitudes
     } else {
       // no zero suppression, put some noise emulation in **all** empty channels
-      auto noise[this] () {
+      // lambda function just to shorten call to noise injector
+      auto noise = [this](){
         return noiseInjector_->Gaus(0,avgNoiseRMS_); 
-      } 
+      }; 
+      // loop through all channels
       for (int layer{0}; layer < nEcalLayers; layer++) {
         for (int module{0}; module < nModulesPerLayer; module++) {
           for (int cell{0}; cell < nCellsPerModule; cell++) {
@@ -213,8 +215,8 @@ void EcalDigiProducer::produce(framework::Event& event) {
               continue;
             // channel is empty -> put some noise in it
             // get chip conditions from emulator
-            double pedestal{hgcroc->pedestal(channel)};
-            double gain{hgcroc->gain(channel)};
+            double pedestal{hgcroc_->pedestal(channel)};
+            double gain{hgcroc_->gain(channel)};
             // fill a digi with noise samples
             std::vector<ldmx::HgcrocDigiCollection::Sample> noise_digi;
             for (int iADC{0}; iADC<nADCs_; iADC++) {

--- a/src/Ecal/EcalRecProducer.cxx
+++ b/src/Ecal/EcalRecProducer.cxx
@@ -116,7 +116,7 @@ void EcalRecProducer::produce(framework::Event& event) {
       if (digi.isTOT()) msg << "TOT " << digi.tot();
       else msg << "ADC " << digi.soi().adc_t();
       msg << "below pedestal.";
-      EXCEPTION_RAISE("BadRec", msg.str());
+      //EXCEPTION_RAISE("BadRec", msg.str());
     }
 
     double num_mips_equivalent = charge / charge_per_mip_;

--- a/src/Ecal/EcalRecProducer.cxx
+++ b/src/Ecal/EcalRecProducer.cxx
@@ -110,14 +110,18 @@ void EcalRecProducer::produce(framework::Event& event) {
        */
     }
 
-    if (charge < 0) {
-      std::stringstream msg;
-      msg << "Recieved ";
-      if (digi.isTOT()) msg << "TOT " << digi.tot();
-      else msg << "ADC " << digi.soi().adc_t();
-      msg << "below pedestal.";
-      //EXCEPTION_RAISE("BadRec", msg.str());
-    }
+    /** Negative Electron (charge) count
+     * This reconstruction error occurs when the ADC value
+     * is below the ADC pedestal for that channel. In the
+     * normal running mode, this will never happen because
+     * our front-end (the digi emulator or the digitizer itself)
+     * will suppress any signals that are below the readout
+     * threshold. Nevertheless, in some running modes, we
+     * don't have this zero suppression, so we need to 
+     * check that the reconstruction charge (count of electrons)
+     * is non-negative.
+     */
+    if (charge < 0) continue;
 
     double num_mips_equivalent = charge / charge_per_mip_;
     double energy_deposited_in_Si = num_mips_equivalent * mip_si_energy_;


### PR DESCRIPTION
This code utilizes the new emulator method that creates a noise digi when provided with an amplitude instead of using the real-hit digitization method (which adds noise itself).

Moreover, we add a "No zero suppression" method which allows **all** empty channels to be filled with noise hits instead of only filling a number of empty channels determined by the noise generator.