### PR TITLE
Use rec_coll_name instead of hardcoding it; very simple change

### DIFF
--- a/src/Ecal/EcalVetoProcessor.cxx
+++ b/src/Ecal/EcalVetoProcessor.cxx
@@ -297,7 +297,7 @@ void EcalVetoProcessor::produce(framework::Event &event) {
 
   // Get the collection of digitized Ecal hits from the event.
   const std::vector<ldmx::EcalHit> ecalRecHits =
-      event.getCollection<ldmx::EcalHit>("EcalRecHits", rec_pass_name_);
+      event.getCollection<ldmx::EcalHit>(rec_coll_name_, rec_pass_name_);
 
   ldmx::EcalID globalCentroid =
       GetShowerCentroidIDAndRMS(ecalRecHits, showerRMS_);


### PR DESCRIPTION
Turns out this was a one-liner!  rec_coll_name had been defined but was unused.  I tested the change with the 2e config I've been using, and both the config structure and the output branch name neatly parallel the HCal now.