### PR TITLE
Patch one of the two buffer overflows

### DIFF
--- a/src/Ecal/EcalVetoProcessor.cxx
+++ b/src/Ecal/EcalVetoProcessor.cxx
@@ -910,7 +910,7 @@ void EcalVetoProcessor::fillIsolatedHitMap(
     //  these ideas are only cell/module (must ignore layer)
     std::vector<ldmx::EcalID> cellNbrIds = geometry_->getNN(id);
 
-    for (int k = 0; k < 6; k++) {
+    for (int k = 0; k < cellNbrIds.size(); k++) {
       // update neighbor ID to the current layer
       cellNbrIds[k] = ldmx::EcalID(id.layer(), cellNbrIds[k].module(),
                                    cellNbrIds[k].cell());


### PR DESCRIPTION
See https://github.com/LDMX-Software/ldmx-sw/issues/1166 for the details, this patches one of the two memory bugs in the Ecal veto processor. 

I'm leaving the other since there is no obvious workaround/fix. 