### PR TITLE
remove eventdef and add event object headers

### DIFF
--- a/include/Ecal/EcalRecProducer.h
+++ b/include/Ecal/EcalRecProducer.h
@@ -19,7 +19,6 @@
 //----------//
 #include "DetDescr/DetectorID.h"
 #include "DetDescr/EcalID.h"
-#include "Framework/EventDef.h"
 #include "Framework/EventProcessor.h"
 
 namespace ecal {

--- a/src/Ecal/EcalRecProducer.cxx
+++ b/src/Ecal/EcalRecProducer.cxx
@@ -7,6 +7,9 @@
 #include "Ecal/EcalRecProducer.h"
 #include "DetDescr/EcalGeometry.h"
 #include "Ecal/EcalReconConditions.h"
+#include "Ecal/Event/EcalHit.h"
+#include "Recon/Event/HgcrocDigiCollection.h"
+#include "SimCore/Event/SimCalorimeterHit.h"
 
 namespace ecal {
 


### PR DESCRIPTION
https://github.com/LDMX-Software/ldmx-sw/pull/1251 for context.

Refactoring of the dictionary building infrastructure removed the `EventDef.h` header. This PR just removes that header and includes the specific event objects needed for the processors instead.