### PR TITLE
add config for studying ecal resolution

### DIFF
--- a/exampleConfigs/ecal-resolution-study-with-trig-prim.py
+++ b/exampleConfigs/ecal-resolution-study-with-trig-prim.py
@@ -1,0 +1,91 @@
+"""Ecal-focused config script
+
+This config script allows the user to choose the energy and angle
+of the electron as it enters the front face of the ECal. After the
+simulation, it runs the EcalDigiProducer, EcalRecProducer, and
+EcalTrigPrimDigiProducer for studying how the Ecal handles the
+input electron.
+
+    ldmx fire ecal-resolution-study-with-trig-prim.py --help
+"""
+
+import argparse
+import os
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('--n-events',default=10,type=int,help='number of events to simulate')
+parser.add_argument('--run',default=1,help='run number (controls random number seeding)')
+parser.add_argument('--out-dir',default=os.getcwd(),help='directory to put output file into')
+parser.add_argument('--energy',default=4.,help='energy of incident electron in GeV')
+parser.add_argument('--theta',default=0,help='angle incident electron makes with respect to z-axis in degrees')
+parser.add_argument('--phi', default=0, help='azimuthal angle incident electron makes')
+parser.add_argument('--angle-at-target',action='store_true', help='have the initial position shift so that the angles are from the target')
+
+arg = parser.parse_args()
+
+from LDMX.Framework import ldmxcfg
+
+if not os.path.isdir(arg.out_dir) :
+    raise KeyError(f'Need to create output directory {arg.out_dir}')
+
+p = ldmxcfg.Process( "valid" )
+p.run = arg.run
+p.maxEvents = arg.n_events
+p.maxTriesPerEvent = 10000
+file_stub = f'energy_{arg.energy}_theta_{arg.theta:02d}_phi_{arg.phi}_attarget_{arg.angle_at_target}_geometry_v14_events_{arg.n_events}_run_{arg.run}.root'
+p.outputFiles = [ arg.out_dir+'/type_events_'+file_stub ]
+p.histogramFile = arg.out_dir+'/type_histos_'+file_stub
+
+# we want to see every event
+p.logFrequency = 1000
+p.termLogLevel = 0
+
+from LDMX.SimCore import simulator
+from LDMX.SimCore import generators
+import LDMX.Ecal.EcalGeometry
+import LDMX.Ecal.ecal_hardcoded_conditions
+import LDMX.Hcal.HcalGeometry
+import LDMX.Ecal.digi as ecal_digi
+import LDMX.Ecal.ecal_trig_digi as ecal_trig_digi
+
+electrons = generators.gun('ecal-electrons')
+electrons.particle = 'e-'
+electrons.energy = arg.energy
+# for now, we are just going to have phi=0 meaning all angular
+#  movement is put along the horizontal x-axis
+# this is a good first-pass study since the horizontal plane
+#  is where most particles are bent due to the magnetic field
+#  surrounding the tracker
+from math import sin, cos, tan, pi
+phi = arg.phi * pi/180
+theta = arg.theta * pi/180
+electrons.direction = [sin(theta)*cos(phi), sin(theta)*sin(phi), cos(theta)]
+# the front of the ECal is at z=240mm
+# the last recoil tracking layer is at z=188mm
+# we don't want anything else mucking up the particle before hitting the Ecal
+#  so that we can easily know what the "true" value of something is, so
+#  we want to keep z between ~200 and 240
+z = 220. # mm - in front of ECal but skipping tracker/target material
+# if we wanted the angles to be angles _from the target_, we need to 
+#  shift the electron transverse (x and y) position as well so that
+#  the electron avoids material /and/ looks like it came from the target
+# or we could just have it be angles without moving the particle
+#  this would be helpful for seeing how the angle of the particle
+#  affects the resolution without having to worry about containment as much
+electrons.position = [z*tan(theta)*cos(phi), z*tan(theta)*sin(phi), z] if arg.angle_at_target else [0., 0., z]
+
+validator = simulator.simulator('plain')
+validator.setDetector(f'ldmx-det-v14', False)
+validator.description = 'Electrons straight into ECal for ECal geometry testing'
+validator.generators = [electrons]
+
+# turn off all PN interactions so we have a "clean" EM shower
+from LDMX.SimCore import photonuclear_models as pn
+validator.photonuclear_model = pn.NoPhotoNuclearModel()
+
+digi = ecal_digi.EcalDigiProducer()
+prec_rec = ecal_digi.EcalRecProducer()
+trig_digi = ecal_trig_digi.EcalTrigPrimDigiProducer()
+
+p.sequence = [ validator, digi, prec_rec, trig_digi ]

--- a/exampleConfigs/ecal-resolution-study-with-trig-prim.py
+++ b/exampleConfigs/ecal-resolution-study-with-trig-prim.py
@@ -35,7 +35,6 @@ p.maxEvents = arg.n_events
 p.maxTriesPerEvent = 10000
 file_stub = f'energy_{arg.energy}_theta_{arg.theta:02d}_phi_{arg.phi}_attarget_{arg.angle_at_target}_geometry_v14_events_{arg.n_events}_run_{arg.run}.root'
 p.outputFiles = [ arg.out_dir+'/type_events_'+file_stub ]
-p.histogramFile = arg.out_dir+'/type_histos_'+file_stub
 
 # we want to see every event
 p.logFrequency = 1000
@@ -52,11 +51,6 @@ import LDMX.Ecal.ecal_trig_digi as ecal_trig_digi
 electrons = generators.gun('ecal-electrons')
 electrons.particle = 'e-'
 electrons.energy = arg.energy
-# for now, we are just going to have phi=0 meaning all angular
-#  movement is put along the horizontal x-axis
-# this is a good first-pass study since the horizontal plane
-#  is where most particles are bent due to the magnetic field
-#  surrounding the tracker
 from math import sin, cos, tan, pi
 phi = arg.phi * pi/180
 theta = arg.theta * pi/180

--- a/exampleConfigs/trig-prim-analyzer.py
+++ b/exampleConfigs/trig-prim-analyzer.py
@@ -1,0 +1,46 @@
+"""Run TrigPrimResolutionAnalyzer over an already-created file
+
+    ldmx fire trig-prim-analyzer.py --help
+"""
+
+import argparse
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('--max-events',default=None,type=int,help='maximum number of events to process (helpful to limit while test-running)')
+parser.add_argument('--out-dir',default=Path.cwd(),help='directory to put output histogram file')
+parser.add_argument('--out-name',default=None,help='name output histogram file (default is to deduce a name from the input file)')
+parser.add_argument('input_file',nargs='+',type=Path,help='input file(s) to run analyzer over')
+
+arg = parser.parse_args()
+
+if len(arg.input_file) > 1 and arg.out_name is None:
+    parser.error('Need to give --out-name if more than one input file is given.')
+elif arg.out_name is None:
+    arg.out_name = arg.input_file[0].stem
+    if 'type_events' in arg.out_name:
+        arg.out_name = arg.out_name.replace('events','histos')
+    else:
+        arg.out_name += '_histos'
+    arg.out_name += '.root'
+
+if not arg.out_dir.is_dir():
+    parser.error(f'Output directory {arg.out_dir} does not exist. Is it mounted to the container? Do you need to create it?')
+
+from LDMX.Framework import ldmxcfg
+
+p = ldmxcfg.Process( "valid" )
+if arg.max_events is not None:
+    p.maxEvents = arg.max_events
+
+p.inputFiles = [str(path) for path in arg.input_file]
+p.histogramFile = str(arg.out_dir / arg.out_name)
+
+# print updates every 1k events
+p.logFrequency = 1000
+p.termLogLevel = 0
+
+p.sequence = [
+    ldmxcfg.Analyzer('resolution','ldmx::ecal::TrigPrimResolutionAnalyzer','Ecal')
+]

--- a/src/Ecal/TrigPrimResolutionAnalyzer.cxx
+++ b/src/Ecal/TrigPrimResolutionAnalyzer.cxx
@@ -24,12 +24,21 @@ class TrigPrimResolutionAnalyzer : public framework::Analyzer {
 };
 
 void TrigPrimResolutionAnalyzer::configure(framework::config::Parameters& parameters) {
-  digi_collection_name_ = parameters.getParameter("digi_collection_name", digi_collection_name_);
-  digi_pass_name_ = parameters.getParameter("digi_pass_name", digi_pass_name_);
-  trig_collection_name_ = parameters.getParameter("trig_collection_name", trig_collection_name_);
-  trig_pass_name_ = parameters.getParameter("trig_pass_name", trig_pass_name_);
-  hit_collection_name_ = parameters.getParameter("hit_collection_name", hit_collection_name_);
-  hit_pass_name_ = parameters.getParameter("hit_pass_name", hit_pass_name_);
+  /*
+   * Since I defined these member variables to have sensible values in the declaration above,
+   * we DO NOT get their parameter values from the python config. Below, I have written out
+   * the lines that we could use to get their values from the python config if changing them
+   * is desirable (e.g. if you want to run a few different passes of digi and recon with different
+   * parameters and then want to analyze the different passes).
+   */
+  /*
+  digi_collection_name_ = parameters.getParameter("digi_collection_name");
+  digi_pass_name_ = parameters.getParameter("digi_pass_name");
+  trig_collection_name_ = parameters.getParameter("trig_collection_name");
+  trig_pass_name_ = parameters.getParameter("trig_pass_name");
+  hit_collection_name_ = parameters.getParameter("hit_collection_name");
+  hit_pass_name_ = parameters.getParameter("hit_pass_name");
+  */
 }
 
 void TrigPrimResolutionAnalyzer::onProcessStart() {
@@ -37,7 +46,13 @@ void TrigPrimResolutionAnalyzer::onProcessStart() {
   // first, we get the directory for this processor in the histogram file
   getHistoDirectory();
   // then we can create histograms within it
+  histograms_.create(
+      "total_trig_energy" /* name - as written in output ROOT file */,
+      "Total of all Trig Digis" /* xlabel - axis label of histogram */,
+      1000 /* number of bins */, 0 /* minimum value */, 10000 /* maximum value */
+  ); // WARNING: I don't think this binning is good!! I just picked a random number!!
   /*
+   * 2D Histograms are also possible
   histograms_.create(
       "name",
       "xlabel", nbins, xstart, xend,
@@ -54,9 +69,33 @@ void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
   // digis are a ldmx::HgcrocDigiCollection
   const auto& hits  = event.getCollection<ldmx::EcalHit>(hit_collection_name_, hit_pass_name_);
   // hits are a std::vector<ldmx::EcalHit>
+
+  int total{0};
+  for (const auto& trig : trigs) {
+    total += trig.linearPrimitive();
+  }
+
+  /*
+   * after picking some dummy bins, I printout the values I'm going to fill
+   * so I can see what an actual binning should be. For 10 events, the output was
+   * 978
+   * 949
+   * 1070
+   * 858
+   * 846
+   * 774
+   * 853
+   * 859
+   * 887
+   * 917
+   * so I changed the binning to 1k bins ranging from 0 to 10k
+  std::cout << total << std::endl;
+   */
+  histograms_.fill("total_trig_energy", total);
   
   /*
-  histograms_.fill(xvalue, yvalue);
+   * 2D fill example
+  histograms_.fill("name", xvalue, yvalue);
   */
 }
 

--- a/src/Ecal/TrigPrimResolutionAnalyzer.cxx
+++ b/src/Ecal/TrigPrimResolutionAnalyzer.cxx
@@ -1,0 +1,33 @@
+#include "Framework/Analyzer.h"
+
+#include "Ecal/Event/EcalHit.h"
+#include "Recon/Event/HgcrocTrigDigi.h"
+#include "Recon/Event/HgcrocDigiCollection.h"
+
+namespace ldmx::ecal {
+class TrigPrimResolutionAnalyzer : public framework::Analyzer {
+  // private member variables (if need be)
+ public:
+  TrigPrimResolutionAnalyzer(const std::string& name, framework::Process& process)
+    : framework::Analyzer(name, process) {}
+  virtual ~TrigPrimResolutionAnalyzer() = default;
+  void configure(framework::config::Parameters& parameters) final;
+  void onProcessStart() final;
+  void analyze(const framework::Event& event) final;
+};
+
+void TrigPrimResolutionAnalyzer::configure(framework::config::Parameters& parameters) {
+  // configure yourself by getting parameters from python (if need b)
+}
+
+void TrigPrimResolutionAnalyzer::onProcessStart() final {
+  // initialize processing by making histograms and such
+}
+
+void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) final {
+  // called once on each event, get objects and fill histograms
+}
+
+}
+
+DECLARE_ANALYZER_NS(ldmx::ecal, TrigPrimResolutionAnalyzer);

--- a/src/Ecal/TrigPrimResolutionAnalyzer.cxx
+++ b/src/Ecal/TrigPrimResolutionAnalyzer.cxx
@@ -1,12 +1,19 @@
-#include "Framework/Analyzer.h"
+#include "Framework/EventProcessor.h"
 
 #include "Ecal/Event/EcalHit.h"
 #include "Recon/Event/HgcrocTrigDigi.h"
 #include "Recon/Event/HgcrocDigiCollection.h"
+#include "DetDescr/EcalID.h"
+#include "DetDescr/EcalTriggerID.h"
 
 namespace ldmx::ecal {
 class TrigPrimResolutionAnalyzer : public framework::Analyzer {
-  // private member variables (if need be)
+  std::string digi_collection_name_ = "EcalDigis";
+  std::string digi_pass_name_ = "";
+  std::string trig_collection_name_ = "ecalTrigDigis";
+  std::string trig_pass_name_ = "";
+  std::string hit_collection_name_ = "EcalRecHits";
+  std::string hit_pass_name_ = "";
  public:
   TrigPrimResolutionAnalyzer(const std::string& name, framework::Process& process)
     : framework::Analyzer(name, process) {}
@@ -17,15 +24,40 @@ class TrigPrimResolutionAnalyzer : public framework::Analyzer {
 };
 
 void TrigPrimResolutionAnalyzer::configure(framework::config::Parameters& parameters) {
-  // configure yourself by getting parameters from python (if need b)
+  digi_collection_name_ = parameters.getParameter("digi_collection_name", digi_collection_name_);
+  digi_pass_name_ = parameters.getParameter("digi_pass_name", digi_pass_name_);
+  trig_collection_name_ = parameters.getParameter("trig_collection_name", trig_collection_name_);
+  trig_pass_name_ = parameters.getParameter("trig_pass_name", trig_pass_name_);
+  hit_collection_name_ = parameters.getParameter("hit_collection_name", hit_collection_name_);
+  hit_pass_name_ = parameters.getParameter("hit_pass_name", hit_pass_name_);
 }
 
-void TrigPrimResolutionAnalyzer::onProcessStart() final {
+void TrigPrimResolutionAnalyzer::onProcessStart() {
   // initialize processing by making histograms and such
+  // first, we get the directory for this processor in the histogram file
+  getHistoDirectory();
+  // then we can create histograms within it
+  /*
+  histograms_.create(
+      "name",
+      "xlabel", nbins, xstart, xend,
+      "ylabel", nbins, ystart, yend
+  );
+  */
 }
 
-void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) final {
+void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
   // called once on each event, get objects and fill histograms
+  const auto& trigs = event.getCollection<ldmx::HgcrocTrigDigi>(trig_collection_name_, trig_pass_name_);
+  // trigs are a std::vector<ldmx::HgcrocTrigDigi>
+  const auto& digis = event.getObject<ldmx::HgcrocDigiCollection>(digi_collection_name_, digi_pass_name_);
+  // digis are a ldmx::HgcrocDigiCollection
+  const auto& hits  = event.getCollection<ldmx::EcalHit>(hit_collection_name_, hit_pass_name_);
+  // hits are a std::vector<ldmx::EcalHit>
+  
+  /*
+  histograms_.fill(xvalue, yvalue);
+  */
 }
 
 }


### PR DESCRIPTION
I've copied this config around for awhile so it is time to put it into the repository.

This config is focused on firing electrons _directly_ into the ECal and then running the various processors that emulate electronics and reconstruct stuff within the ECal so users can then analyze the output.

## To Do
- [ ] Write a processor that re-calculates the trigger primitives using the precision rec hits. This allows us to see how imprecise the trigger primitive "condensation" algorithm is.
- [ ] Compare module-level sum between trigger primitives and precision rec hits
- [ ] Compare trigger primitives to trigger-group-sum of precision rec hits
- [ ] ...something else?