### PR TITLE
Build ECal clusters on a base class

### DIFF
--- a/include/Ecal/Event/EcalCluster.h
+++ b/include/Ecal/Event/EcalCluster.h
@@ -72,6 +72,11 @@ class EcalCluster {
    */
   void setIDs(std::vector<unsigned int>& hitIDs) { hitIDs_ = hitIDs; }
 
+  void setHitValsX(std::vector<float>& x) { hitX_ = x; }
+  void setHitValsY(std::vector<float>& x) { hitY_ = x; }
+  void setHitValsZ(std::vector<float>& x) { hitZ_ = x; }
+  void setHitValsE(std::vector<float>& x) { hitE_ = x; }
+
   /**
    * Sets the three coordinates of the cluster centroid
    * @param x The x coordinate.
@@ -123,6 +128,12 @@ class EcalCluster {
 
   const std::vector<unsigned int>& getHitIDs() const { return hitIDs_; }
 
+  // ability to store limited hit info
+  const std::vector<float>& getHitX() const { return hitX_; }
+  const std::vector<float>& getHitY() const { return hitY_; }
+  const std::vector<float>& getHitZ() const { return hitZ_; }
+  const std::vector<float>& getHitE() const { return hitE_; }
+
   bool operator<(const EcalCluster& rhs) const {
     return this->getEnergy() < rhs.getEnergy();
   }
@@ -141,6 +152,10 @@ class EcalCluster {
   double DYDZ_{0};
   double errDXDZ_{0};
   double errDYDZ_{0};
+  std::vector<float> hitX_;
+  std::vector<float> hitY_;
+  std::vector<float> hitZ_;
+  std::vector<float> hitE_;
 
   ClassDef(EcalCluster, 1);
 };

--- a/include/Ecal/Event/EcalCluster.h
+++ b/include/Ecal/Event/EcalCluster.h
@@ -84,6 +84,19 @@ class EcalCluster {
     centroidZ_ = z;
   }
 
+  void setRMSXYZ(double x, double y, double z) {
+    rmsX_ = x;
+    rmsY_ = y;
+    rmsZ_ = z;
+  }
+  void setDXDZ(double x) { DXDZ_=x; }
+
+  void setDYDZ(double x) { DYDZ_=x; }
+
+  void setEDXDZ(double x) { errDXDZ_=x; }
+
+  void setEDYDZ(double x) { errDYDZ_=x; }
+
   double getEnergy() const { return energy_; }
 
   int getNHits() const { return nHits_; }
@@ -93,6 +106,20 @@ class EcalCluster {
   double getCentroidY() const { return centroidY_; }
 
   double getCentroidZ() const { return centroidZ_; }
+
+  double getRMSX() const { return rmsX_; }
+
+  double getRMSY() const { return rmsY_; }
+
+  double getRMSZ() const { return rmsZ_; }
+
+  double getDXDZ() const { return DXDZ_; }
+
+  double getDYDZ() const { return DYDZ_; }
+
+  double getEDXDZ() const { return errDXDZ_; }
+
+  double getEDYDZ() const { return errDYDZ_; }
 
   const std::vector<unsigned int>& getHitIDs() const { return hitIDs_; }
 
@@ -107,6 +134,13 @@ class EcalCluster {
   double centroidX_{0};
   double centroidY_{0};
   double centroidZ_{0};
+  double rmsX_{0};
+  double rmsY_{0};
+  double rmsZ_{0};
+  double DXDZ_{0};
+  double DYDZ_{0};
+  double errDXDZ_{0};
+  double errDYDZ_{0};
 
   ClassDef(EcalCluster, 1);
 };

--- a/include/Ecal/Event/EcalCluster.h
+++ b/include/Ecal/Event/EcalCluster.h
@@ -7,16 +7,17 @@
 #ifndef EVENT_ECALCLUSTER_H_
 #define EVENT_ECALCLUSTER_H_
 
-// ROOT
-#include "TObject.h"  //For ClassDef
-#include "TString.h"
+/* // ROOT */
+/* #include "TObject.h"  //For ClassDef */
+/* #include "TString.h" */
 
-// STL
-#include <iostream>
-#include <set>
+/* // STL */
+/* #include <iostream> */
+/* #include <set> */
 
 // ldmx-sw
 #include "Ecal/Event/EcalHit.h"
+#include "Recon/Event/CaloCluster.h"
 
 namespace ldmx {
 
@@ -24,7 +25,7 @@ namespace ldmx {
  * @class EcalCluster
  * @brief Stores cluster information from the ECal
  */
-class EcalCluster {
+class EcalCluster : public ldmx::CaloCluster {
  public:
   /**
    * Class constructor.
@@ -36,15 +37,15 @@ class EcalCluster {
    */
   virtual ~EcalCluster();
 
-  /**
-   * Print a description of this object.
-   */
-  void Print() const;
+  /* /\** */
+  /*  * Print a description of this object. */
+  /*  *\/ */
+  /* void Print() const; */
 
-  /**
-   * Reset the EcalCluster object.
-   */
-  void Clear();
+  /* /\** */
+  /*  * Reset the EcalCluster object. */
+  /*  *\/ */
+  /* void Clear(); */
 
   /**
    * Take in the hits that make up the cluster.
@@ -53,109 +54,109 @@ class EcalCluster {
    */
   void addHits(const std::vector<const ldmx::EcalHit*> hitsVec);
 
-  /**
-   * Sets total energy for the cluster.
-   * @param energy The total energy of the cluster.
-   */
-  void setEnergy(double energy) { energy_ = energy; }
+  /* /\** */
+  /*  * Sets total energy for the cluster. */
+  /*  * @param energy The total energy of the cluster. */
+  /*  *\/ */
+  /* void setEnergy(double energy) { energy_ = energy; } */
 
-  /**
-   * Sets total number of hits in the cluster.
-   * @param nHits The total number of hits.
-   */
-  void setNHits(int nHits) { nHits_ = nHits; }
+  /* /\** */
+  /*  * Sets total number of hits in the cluster. */
+  /*  * @param nHits The total number of hits. */
+  /*  *\/ */
+  /* void setNHits(int nHits) { nHits_ = nHits; } */
 
-  /**
-   * Sets a sorted vector for the IDs of the hits
-   * that make up the cluster.
-   * @param IDs Sorted vector of hit IDs.
-   */
-  void setIDs(std::vector<unsigned int>& hitIDs) { hitIDs_ = hitIDs; }
+  /* /\** */
+  /*  * Sets a sorted vector for the IDs of the hits */
+  /*  * that make up the cluster. */
+  /*  * @param IDs Sorted vector of hit IDs. */
+  /*  *\/ */
+  /* void setIDs(std::vector<unsigned int>& hitIDs) { hitIDs_ = hitIDs; } */
 
-  void setHitValsX(std::vector<float>& x) { hitX_ = x; }
-  void setHitValsY(std::vector<float>& x) { hitY_ = x; }
-  void setHitValsZ(std::vector<float>& x) { hitZ_ = x; }
-  void setHitValsE(std::vector<float>& x) { hitE_ = x; }
+  /* void setHitValsX(std::vector<float>& x) { hitX_ = x; } */
+  /* void setHitValsY(std::vector<float>& x) { hitY_ = x; } */
+  /* void setHitValsZ(std::vector<float>& x) { hitZ_ = x; } */
+  /* void setHitValsE(std::vector<float>& x) { hitE_ = x; } */
 
-  /**
-   * Sets the three coordinates of the cluster centroid
-   * @param x The x coordinate.
-   * @param y The y coordinate.
-   * @param z The z coordinate.
-   */
-  void setCentroidXYZ(double x, double y, double z) {
-    centroidX_ = x;
-    centroidY_ = y;
-    centroidZ_ = z;
-  }
+  /* /\** */
+  /*  * Sets the three coordinates of the cluster centroid */
+  /*  * @param x The x coordinate. */
+  /*  * @param y The y coordinate. */
+  /*  * @param z The z coordinate. */
+  /*  *\/ */
+  /* void setCentroidXYZ(double x, double y, double z) { */
+  /*   centroidX_ = x; */
+  /*   centroidY_ = y; */
+  /*   centroidZ_ = z; */
+  /* } */
 
-  void setRMSXYZ(double x, double y, double z) {
-    rmsX_ = x;
-    rmsY_ = y;
-    rmsZ_ = z;
-  }
-  void setDXDZ(double x) { DXDZ_=x; }
+  /* void setRMSXYZ(double x, double y, double z) { */
+  /*   rmsX_ = x; */
+  /*   rmsY_ = y; */
+  /*   rmsZ_ = z; */
+  /* } */
+  /* void setDXDZ(double x) { DXDZ_=x; } */
 
-  void setDYDZ(double x) { DYDZ_=x; }
+  /* void setDYDZ(double x) { DYDZ_=x; } */
 
-  void setEDXDZ(double x) { errDXDZ_=x; }
+  /* void setEDXDZ(double x) { errDXDZ_=x; } */
 
-  void setEDYDZ(double x) { errDYDZ_=x; }
+  /* void setEDYDZ(double x) { errDYDZ_=x; } */
 
-  double getEnergy() const { return energy_; }
+  /* double getEnergy() const { return energy_; } */
 
-  int getNHits() const { return nHits_; }
+  /* int getNHits() const { return nHits_; } */
 
-  double getCentroidX() const { return centroidX_; }
+  /* double getCentroidX() const { return centroidX_; } */
 
-  double getCentroidY() const { return centroidY_; }
+  /* double getCentroidY() const { return centroidY_; } */
 
-  double getCentroidZ() const { return centroidZ_; }
+  /* double getCentroidZ() const { return centroidZ_; } */
 
-  double getRMSX() const { return rmsX_; }
+  /* double getRMSX() const { return rmsX_; } */
 
-  double getRMSY() const { return rmsY_; }
+  /* double getRMSY() const { return rmsY_; } */
 
-  double getRMSZ() const { return rmsZ_; }
+  /* double getRMSZ() const { return rmsZ_; } */
 
-  double getDXDZ() const { return DXDZ_; }
+  /* double getDXDZ() const { return DXDZ_; } */
 
-  double getDYDZ() const { return DYDZ_; }
+  /* double getDYDZ() const { return DYDZ_; } */
 
-  double getEDXDZ() const { return errDXDZ_; }
+  /* double getEDXDZ() const { return errDXDZ_; } */
 
-  double getEDYDZ() const { return errDYDZ_; }
+  /* double getEDYDZ() const { return errDYDZ_; } */
 
-  const std::vector<unsigned int>& getHitIDs() const { return hitIDs_; }
+  /* const std::vector<unsigned int>& getHitIDs() const { return hitIDs_; } */
 
-  // ability to store limited hit info
-  const std::vector<float>& getHitX() const { return hitX_; }
-  const std::vector<float>& getHitY() const { return hitY_; }
-  const std::vector<float>& getHitZ() const { return hitZ_; }
-  const std::vector<float>& getHitE() const { return hitE_; }
+  /* // ability to store limited hit info */
+  /* const std::vector<float>& getHitX() const { return hitX_; } */
+  /* const std::vector<float>& getHitY() const { return hitY_; } */
+  /* const std::vector<float>& getHitZ() const { return hitZ_; } */
+  /* const std::vector<float>& getHitE() const { return hitE_; } */
 
   bool operator<(const EcalCluster& rhs) const {
     return this->getEnergy() < rhs.getEnergy();
   }
 
  private:
-  std::vector<unsigned int> hitIDs_;
-  double energy_{0};
-  int nHits_{0};
-  double centroidX_{0};
-  double centroidY_{0};
-  double centroidZ_{0};
-  double rmsX_{0};
-  double rmsY_{0};
-  double rmsZ_{0};
-  double DXDZ_{0};
-  double DYDZ_{0};
-  double errDXDZ_{0};
-  double errDYDZ_{0};
-  std::vector<float> hitX_;
-  std::vector<float> hitY_;
-  std::vector<float> hitZ_;
-  std::vector<float> hitE_;
+  /* std::vector<unsigned int> hitIDs_; */
+  /* double energy_{0}; */
+  /* int nHits_{0}; */
+  /* double centroidX_{0}; */
+  /* double centroidY_{0}; */
+  /* double centroidZ_{0}; */
+  /* double rmsX_{0}; */
+  /* double rmsY_{0}; */
+  /* double rmsZ_{0}; */
+  /* double DXDZ_{0}; */
+  /* double DYDZ_{0}; */
+  /* double errDXDZ_{0}; */
+  /* double errDYDZ_{0}; */
+  /* std::vector<float> hitX_; */
+  /* std::vector<float> hitY_; */
+  /* std::vector<float> hitZ_; */
+  /* std::vector<float> hitE_; */
 
   ClassDef(EcalCluster, 1);
 };

--- a/src/Ecal/Event/EcalCluster.cxx
+++ b/src/Ecal/Event/EcalCluster.cxx
@@ -27,6 +27,13 @@ ClassImp(ldmx::EcalCluster)
     centroidX_ = 0;
     centroidY_ = 0;
     centroidZ_ = 0;
+    rmsX_ = 0;
+    rmsY_ = 0;
+    rmsZ_ = 0;
+    DXDZ_ = 0;
+    DYDZ_ = 0;
+    errDXDZ_ = 0;
+    errDYDZ_ = 0;
   }
 
   void EcalCluster::addHits(const std::vector<const EcalHit *> hitsVec) {

--- a/src/Ecal/Event/EcalCluster.cxx
+++ b/src/Ecal/Event/EcalCluster.cxx
@@ -7,34 +7,34 @@ ClassImp(ldmx::EcalCluster)
 
   EcalCluster::~EcalCluster() { Clear(); }
 
-  void EcalCluster::Print() const {
-    std::cout << "EcalCluster { "
-              << "Energy: " << energy_ << ", "
-              << "Number of hits: " << nHits_ << " }" << std::endl;
+  // void EcalCluster::Print() const {
+  //   std::cout << "EcalCluster { "
+  //             << "Energy: " << energy_ << ", "
+  //             << "Number of hits: " << nHits_ << " }" << std::endl;
 
-    // for (int iHit = 0; iHit < hits_->GetEntries(); ++iHit) {
-    //    ldmx::EcalHit* aHit = (ldmx::EcalHit*) hits_->At(iHit);
-    //    std::cout << "Hit " << iHit << " : " << "with energy " <<
-    //    aHit->getEnergy() << std::endl;
-    //}
-  }
+  //   // for (int iHit = 0; iHit < hits_->GetEntries(); ++iHit) {
+  //   //    ldmx::EcalHit* aHit = (ldmx::EcalHit*) hits_->At(iHit);
+  //   //    std::cout << "Hit " << iHit << " : " << "with energy " <<
+  //   //    aHit->getEnergy() << std::endl;
+  //   //}
+  // }
 
-  void EcalCluster::Clear() {
-    hitIDs_.clear();
+  // void EcalCluster::Clear() {
+  //   hitIDs_.clear();
 
-    energy_ = 0;
-    nHits_ = 0;
-    centroidX_ = 0;
-    centroidY_ = 0;
-    centroidZ_ = 0;
-    rmsX_ = 0;
-    rmsY_ = 0;
-    rmsZ_ = 0;
-    DXDZ_ = 0;
-    DYDZ_ = 0;
-    errDXDZ_ = 0;
-    errDYDZ_ = 0;
-  }
+  //   energy_ = 0;
+  //   nHits_ = 0;
+  //   centroidX_ = 0;
+  //   centroidY_ = 0;
+  //   centroidZ_ = 0;
+  //   rmsX_ = 0;
+  //   rmsY_ = 0;
+  //   rmsZ_ = 0;
+  //   DXDZ_ = 0;
+  //   DYDZ_ = 0;
+  //   errDXDZ_ = 0;
+  //   errDYDZ_ = 0;
+  // }
 
   void EcalCluster::addHits(const std::vector<const EcalHit *> hitsVec) {
     // double clusterE = 0;


### PR DESCRIPTION
This moves the bulk of the ECal cluster definition into a common CaloCluster object to be shared with HCal to reduce/avoid duplicated code.
See also: https://github.com/LDMX-Software/Hcal/pull/65